### PR TITLE
Add functions to get `Variation`s from `Variant`

### DIFF
--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -304,6 +304,9 @@ function Variant(aln::PairwiseAlignment{T, T}) where {T <: LongSequence{<:Union{
     return result
 end
 
+edits(v::Variant) = v.edits
+reference(v::Variant) = v.ref
+
 function lendiff(edit::Edit)
     x = edit.x
     x isa Substitution ? 0 : (x isa Deletion ? -length(x) : length(x.x))

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -456,12 +456,21 @@ function translate(var::Variation{S, T}, aln::PairwiseAlignment{S, S}) where {S,
     end
 end
 
+function variations(v::Variant)
+    vs = Vector{Variation}(undef, length(edits(v)))
+    for (i, e) in enumerate(edits(v))
+        vs[i] = Variation(reference(v), e)
+    end
+    return vs
+end
+
 export Insertion,
     Deletion,
     Substitution,
     Variant,
     Variation,
     reference,
-    mutation
+    mutation,
+    variations
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,3 +57,15 @@ end
     @test mutation(del) isa Deletion
     @test mutation(ins) isa Insertion
 end
+
+@testset "VariationRetrieval" begin
+    refseq = dna"ACAACTTTATCT"
+    mutseq = dna"ACATCTTTATCT"
+
+    read = AlignedSequence(mutseq[1:10], Alignment("10M", 1, 1))
+    aln = PairwiseAlignment(read, refseq)
+    var = Variant(aln)
+
+    sub = Variation(refseq, "A4T")
+    @test first(variations(var)) == sub
+end


### PR DESCRIPTION
Adds

- Accessor functions for `Variant`
  - `edits` (private)
  - `reference` (exported)
- `BioGenerics.rightposition` getter function for `Variation`
  - `BioGenerics.rightposition` getter function for `Edit`
  - `Base.length` getter function for `Edit`
- Tests for `variations` function

Fixes #5 