### PR TITLE
Add reference and alternate base getters for Variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Variation` type to store and compare individual mutations
 - `reconstruct!` function to build mutated sequences from `Variant`s
 - `Variant` constructor to automatically detect mutations from a `BioAlignments.PairwiseAlignment`
+- Methods to get reference and alternate bases from a `Variation`
 
 [unreleased]: https://github.com/BioJulia/SequenceVariation.jl

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -472,6 +472,14 @@ function _altbases(s::Substitution, reference::S, pos::UInt) where S <: BioSeque
     return S([s.x])
 end
 
+function _refbases(d::Deletion, reference::S, pos::UInt) where S <: BioSequence
+    if pos == 1
+        return S(reference[UnitRange{Int}(pos, pos+length(d))])
+    else
+        return S(reference[UnitRange{Int}(pos-1, pos+length(d)-1)])
+    end
+end
+
 export Insertion,
     Deletion,
     Substitution,

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -492,6 +492,14 @@ function _refbases(i::Insertion, reference::S, pos::UInt) where S <: BioSequence
     return S([reference[pos]])
 end
 
+function _altbases(i::Insertion, reference::S, pos::UInt) where S <: BioSequence
+    if pos == 1
+        return S([i.seq..., reference[pos]])
+    else
+        return S([reference[pos], i.seq...])
+    end
+end
+
 export Insertion,
     Deletion,
     Substitution,

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -488,6 +488,10 @@ function _altbases(d::Deletion, reference::S, pos::UInt) where S <: BioSequence
     end
 end
 
+function _refbases(i::Insertion, reference::S, pos::UInt) where S <: BioSequence
+    return S([reference[pos]])
+end
+
 export Insertion,
     Deletion,
     Substitution,

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -504,6 +504,10 @@ function refbases(v::Variation)
     return _refbases(mutation(v), reference(v), leftposition(v))
 end
 
+function altbases(v::Variation)
+    return _altbases(mutation(v), reference(v), leftposition(v))
+end
+
 export Insertion,
     Deletion,
     Substitution,
@@ -512,6 +516,7 @@ export Insertion,
     reference,
     mutation,
     variations,
-    refbases
+    refbases,
+    altbases
 
 end # module

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -367,7 +367,7 @@ function Variation(ref::S, edit::AbstractString) where {S<:BioSequence}
     return Variation{S,T}(ref, e)
 end
 
-reference(v::Variation) = v.reference
+reference(v::Variation) = v.ref
 edit(v::Variation) = v.edit
 mutation(v::Variation) = mutation(edit(v))
 BioGenerics.leftposition(v::Variation) = leftposition(edit(v))

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -468,6 +468,10 @@ function _refbases(s::Substitution, reference::S, pos::UInt) where S <: BioSeque
     return S([reference[pos]])
 end
 
+function _altbases(s::Substitution, reference::S, pos::UInt) where S <: BioSequence
+    return S([s.x])
+end
+
 export Insertion,
     Deletion,
     Substitution,

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -480,6 +480,14 @@ function _refbases(d::Deletion, reference::S, pos::UInt) where S <: BioSequence
     end
 end
 
+function _altbases(d::Deletion, reference::S, pos::UInt) where S <: BioSequence
+    if pos == 1
+        return S([reference[pos+1]])
+    else
+        return S([reference[pos-1]])
+    end
+end
+
 export Insertion,
     Deletion,
     Substitution,

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -500,6 +500,10 @@ function _altbases(i::Insertion, reference::S, pos::UInt) where S <: BioSequence
     end
 end
 
+function refbases(v::Variation)
+    return _refbases(mutation(v), reference(v), leftposition(v))
+end
+
 export Insertion,
     Deletion,
     Substitution,
@@ -507,6 +511,7 @@ export Insertion,
     Variation,
     reference,
     mutation,
-    variations
+    variations,
+    refbases
 
 end # module

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -464,6 +464,10 @@ function variations(v::Variant)
     return vs
 end
 
+function _refbases(s::Substitution, reference::S, pos::UInt) where S <: BioSequence
+    return S([reference[pos]])
+end
+
 export Insertion,
     Deletion,
     Substitution,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,3 +69,33 @@ end
     sub = Variation(refseq, "A4T")
     @test first(variations(var)) == sub
 end
+
+@testset "VariationBases" begin
+    # Test substition bases
+    @test refbases(Variation(dna"ATCGA", "C3G")) == dna"C"
+    @test altbases(Variation(dna"ATCGA", "C3G")) == dna"G"
+
+    # Test single deletion bases
+    @test refbases(Variation(dna"ATCGA", "Δ3-3")) == dna"TC"
+    @test altbases(Variation(dna"ATCGA", "Δ3-3")) == dna"T"
+
+    # Test multiple deletion bases
+    @test refbases(Variation(dna"ATCGA", "Δ3-4")) == dna"TCG"
+    @test altbases(Variation(dna"ATCGA", "Δ3-4")) == dna"T"
+
+    # Test first position deletion
+    @test refbases(Variation(dna"ATCGA", "Δ1-1")) == dna"AT"
+    @test altbases(Variation(dna"ATCGA", "Δ1-1")) == dna"T"
+
+    # Test single insertion bases
+    @test refbases(Variation(dna"ATCGA", "3A")) == dna"C"
+    @test altbases(Variation(dna"ATCGA", "3A")) == dna"CA"
+
+    # Test multiple insertion bases
+    @test refbases(Variation(dna"ATCGA", "3TAG")) == dna"C"
+    @test altbases(Variation(dna"ATCGA", "3TAG")) == dna"CTAG"
+
+    # Test first position insertion
+    @test refbases(Variation(dna"ATCGA", "1C")) == dna"A"
+    @test altbases(Variation(dna"ATCGA", "1C")) == dna"CA"
+end


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Fixes #13

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
