### PR TITLE
Add constructor for Variant based on Variations

### DIFF
--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -211,6 +211,8 @@ function Variant(ref::S, edits::Vector{Edit{S, T}}) where {S<:BioSequence, T<:Bi
     Variant{S, T}(ref, edits)
 end
 
+
+
 function Base.show(io::IO, x::Variant)
     n = length(x.edits)
     print(io, summary(x), " with $n edit$(n > 1 ? "s" : ""):")
@@ -365,6 +367,11 @@ function Variation(ref::S, edit::AbstractString) where {S<:BioSequence}
 
     e = parse(Edit{S,T}, edit)
     return Variation{S,T}(ref, e)
+end
+
+function Variant(ref::S, vars::Vector{Variation{S,T}}) where {S<:BioSequence, T<:BioSymbol}
+    edits = edit.(vars)
+    return Variant{S, T}(ref, edits)
 end
 
 reference(v::Variation) = v.ref

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,13 @@ seq1 = ungap!(dna"--ATGCGTGTTAGCAAC--TTATCGCG")
 seq2 = ungap!(dna"TGATGCGTGT-AGCAACACTTATAGCG")
 var = Variant(align(seq1, seq2))
 
+@testset "VariantRoundtrip" begin
+    for v in variations(var)
+        @test v in var
+        @test v in Variant(seq2, [v])
+    end
+end
+
 @testset "VariationPosition" begin
     refseq = dna"ACAACTTTATCT"
     mutseq = dna"ACATCTTTATCT"


### PR DESCRIPTION
A Variant is a collection of Variations, right? Unfortunately there was no
way to convert a collection of Variations into a Variant, so I added one.

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
