### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ## Changed
+
+- Updated dependency compats ([#21](https://github.com/BioJulia/SequenceVariation.jl/pull/21))
+  - BioAlignments: 2 -> 2,3
+  - BioSequences: 2 -> 2,3
+  - BioSymbols: 4 -> 4,5
+
 ## [0.1.1] - 2022-07-21
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,10 @@ BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 
 [compat]
-BioAlignments = "2.0.0"
+BioAlignments = "2,3"
 BioGenerics = "0.1"
-BioSequences = "2"
-BioSymbols = "4"
+BioSequences = "2,3"
+BioSymbols = "4,5"
 julia = "1.6"
 
 [extras]

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -22,7 +22,7 @@ TODO now:
 
 using BioAlignments: BioAlignments, PairwiseAlignment
 using BioGenerics: BioGenerics, leftposition, rightposition
-using BioSequences: BioSequences, BioSequence, NucleotideSeq, AminoAcidSeq, LongSequence, isgap
+using BioSequences: BioSequences, BioSequence, NucleotideSeq, LongSequence, isgap
 using BioSymbols: BioSymbol
 
 const BA = BioAlignments


### PR DESCRIPTION
Updates the dependencies to take advantage of BioSymbols v5. As SequenceVariation doesn't touch any version-specific APIs of its dependencies, these upgrades are optional, and ranged compat entries have been used.