### PR TITLE
Add type parameterization to variations getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Variations getter now returns type-parameterized vector ([#23](https://github.com/BioJulia/SequenceVariation.jl/pull/23))
+
 ## [0.1.2] - 2022-10-04
 
 - ## Changed

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -463,10 +463,10 @@ function translate(var::Variation{S, T}, aln::PairwiseAlignment{S, S}) where {S,
     end
 end
 
-function variations(v::Variant)
-    vs = Vector{Variation}(undef, length(edits(v)))
+function variations(v::Variant{S,T}) where {S,T}
+    vs = Vector{Variation{S,T}}(undef, length(edits(v)))
     for (i, e) in enumerate(edits(v))
-        vs[i] = Variation(reference(v), e)
+        vs[i] = Variation{S,T}(reference(v), e)
     end
     return vs
 end


### PR DESCRIPTION
I have encountered some cases where having a non-parameterized vector can
crash a downstream process. I don't yet know how to make a MWE of that, but
adding type parameters fixes my problem, and doesn't break any tests here.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
