### PR TITLE
Fix softclips causing Variant construction errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Variations getter now returns type-parameterized vector ([#23](https://github.com/BioJulia/SequenceVariation.jl/pull/23))
 
+### Fixed
+
+- Soft clips at end of alignment causing invalid `Variant`s ([#25](https://github.com/BioJulia/SequenceVariation.jl/issues/25)/[#26](https://github.com/BioJulia/SequenceVariation.jl/pull/26))
+
 ## [0.1.2] - 2022-10-04
 
 - ## Changed

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -246,7 +246,7 @@ function is_valid(v::Variant)
         # for next op. However, we cannot have two insertions at the same position, because
         # then the order of them is ambiguous
         elseif op isa Insertion
-            pos in (first(valid_positions)-1+last_was_insert:last(valid_positions)) || return false
+            pos in (first(valid_positions)-1+last_was_insert:last(valid_positions)+1) || return false
             last_was_insert = true
         # Deletions obviously invalidate the reference bases that are deleted.
         elseif op isa Deletion
@@ -399,7 +399,7 @@ function is_valid(v::Variation)
     if op isa Substitution
         return pos in eachindex(v.ref)
     elseif op isa Insertion
-        return pos in 0:lastindex(v.ref)
+        return pos in 0:lastindex(v.ref)+1
     elseif op isa Deletion
         return pos in 1:(lastindex(v.ref)-length(op) + 1)
     end

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -263,7 +263,6 @@ function Variant(aln::PairwiseAlignment{T, T}) where {T <: LongSequence{<:Union{
     ref = aln.b
     E = eltype(typeof(ref))
     edits = Edit{T, E}[]
-    result = Variant(ref, edits)
     refpos = first(aln.a.aln.anchors).refpos
     seqpos = first(aln.a.aln.anchors).seqpos
     markpos = 0
@@ -312,7 +311,7 @@ function Variant(aln::PairwiseAlignment{T, T}) where {T <: LongSequence{<:Union{
         end
     end
 
-    return result
+    return Variant(ref, edits)
 end
 
 edits(v::Variant) = v.edits

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -308,6 +308,7 @@ end
 
 edits(v::Variant) = v.edits
 reference(v::Variant) = v.ref
+Base.:(==)(x::Variant, y::Variant) = x.ref == y.ref && x.edits == y.edits
 
 function lendiff(edit::Edit)
     x = edit.x

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -20,7 +20,7 @@ TODO now:
 * Add tests
 """
 
-using BioAlignments: BioAlignments, PairwiseAlignment
+using BioAlignments: BioAlignments, PairwiseAlignment, OP_SOFT_CLIP
 using BioGenerics: BioGenerics, leftposition, rightposition
 using BioSequences: BioSequences, BioSequence, NucleotideSeq, LongSequence, isgap
 using BioSymbols: BioSymbol
@@ -300,11 +300,16 @@ function Variant(aln::PairwiseAlignment{T, T}) where {T <: LongSequence{<:Union{
         end
     end
 
+    # Check for clips at the end of the alignment
+    last_anchors = aln.a.aln.anchors[end-1:end]
+
     # Final indel, if applicable
-    if !iszero(n_gaps)
-        push!(edits, Edit{T, E}(Deletion(UInt(n_gaps)), UInt(markpos)))
-    elseif !iszero(n_ins)
-        push!(edits, Edit{T, E}(Insertion(T(insertion_buffer)), UInt(markpos)))
+    if !any(anchor -> anchor.op == OP_SOFT_CLIP, last_anchors)
+        if !iszero(n_gaps)
+            push!(edits, Edit{T, E}(Deletion(UInt(n_gaps)), UInt(markpos)))
+        elseif !iszero(n_ins)
+            push!(edits, Edit{T, E}(Insertion(T(insertion_buffer)), UInt(markpos)))
+        end
     end
 
     return result

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -233,6 +233,10 @@ function is_valid(v::Variant)
     for edit in v.edits
         pos = edit.pos
         op = edit.x
+        # Sanity check: for this to be a valid variant, it must be comprised of valid
+        # variations
+        is_valid(Variation(v.ref, edit)) || return false
+
         # For substitutions we simply do not allow another modification of the same base
         if op isa Substitution
             pos in valid_positions || return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,4 +115,7 @@ end
 
     # Test for ending soft clip
     @test Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3S", 1, 1)), refseq)) == refvar
+
+    # Test for ending soft+hard clip
+    @test Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3S2H", 1, 1)), refseq)) == refvar
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,4 +118,7 @@ end
 
     # Test for ending soft+hard clip
     @test Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3S2H", 1, 1)), refseq)) == refvar
+
+    # Test that ending insertions are still valid
+    @test length(Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3I", 1, 1)), refseq)).edits) == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,4 +121,7 @@ end
 
     # Test that ending insertions are still valid
     @test length(Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3I", 1, 1)), refseq)).edits) == 1
+
+    # Test that out-of-bounds bases are still caught
+    @test_throws BoundsError Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3X", 1, 1)), refseq))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,3 +106,13 @@ end
     @test refbases(Variation(dna"ATCGA", "1C")) == dna"A"
     @test altbases(Variation(dna"ATCGA", "1C")) == dna"CA"
 end
+
+@testset "SoftclipVariant" begin
+    refseq = dna"GATTACA"
+    mutseq = dna"GATTACAAAA"
+
+    refvar = Variant(refseq, SequenceVariation.Edit{typeof(refseq), eltype(refseq)}[])
+
+    # Test for ending soft clip
+    @test Variant(PairwiseAlignment(AlignedSequence(mutseq, Alignment("7=3S", 1, 1)), refseq)) == refvar
+end


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

- [ ] :sparkles: New feature (A non-breaking change which adds functionality).
- [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

This is a direct fix for #25

### Before

```julia-repl
julia> using BioAlignments, BioSequences, SequenceVariation

julia> bad_aln = PairwiseAlignment(AlignedSequence(dna"GATTACAAAA", Alignment("7=3S", 1, 1)), dna"GATTACA")
PairwiseAlignment{LongSequence{DNAAlphabet{4}}, LongSequence{DNAAlphabet{4}}}:
  seq:  1 GATTACAAAA 10
          |||||||   
  ref:  1 GATTACA---  7


julia> Variant(bad_aln)
Variant{LongSequence{DNAAlphabet{4}}, DNA} with 1 edit:Error showing value of type Variant{LongSequence{DNAAlphabet{4}}, DNA}:
ERROR: ArgumentError: Invalid variant
...
```

### This PR

```julia-repl
julia> using BioAlignments, BioSequences, SequenceVariation

julia> bad_aln = PairwiseAlignment(AlignedSequence(dna"GATTACAAAA", Alignment("7=3S", 1, 1)), dna"GATTACA")

PairwiseAlignment{LongSequence{DNAAlphabet{4}}, LongSequence{DNAAlphabet{4}}}:
  seq:  1 GATTACAAAA 10
          |||||||   
  ref:  1 GATTACA---  7


julia> Variant(bad_aln)
Variant{LongSequence{DNAAlphabet{4}}, DNA} with 0 edit:
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
