### PR TITLE
Refactor `reconstruct` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code now follows [Blue style](https://github.com/invenia/BlueStyle) ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
 - :bomb: [BREAKING] Public and private API defined based on Blue style guidelines ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
 - :bomb: [BREAKING] Renamed type `Variant` to `Haplotype` ([#20](https://github.com/BioJulia/SequenceVariation.jl/issues/20)/[#29](https://github.com/BioJulia/SequenceVariation.jl/pull/29))
+- :bomb: [BREAKING] Refactored `reconstruct` function to use `Haplotype`'s reference sequence ([#30](https://github.com/BioJulia/SequenceVariation.jl/pull/30))
 
 ### Removed
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,7 +21,7 @@ Insertion
 Haplotype
 reference(::Haplotype)
 variations
-reconstruct!
+reconstruct
 ```
 
 ## Variations

--- a/docs/src/haplotypes.md
+++ b/docs/src/haplotypes.md
@@ -34,8 +34,7 @@ case when calling variants from alignment files), then the sequence can be
 retrieved using the [`reconstruct`](@ref) function.
 
 ```@repl call_variants
-human2 = copy(bovine);
-reconstruct(human2, bos_human_haplotype)
+human2 = reconstruct(bos_human_haplotype)
 human2 == bovine
 human2 == human
 ```

--- a/docs/src/haplotypes.md
+++ b/docs/src/haplotypes.md
@@ -31,11 +31,11 @@ bos_human_haplotype = Haplotype(bos_human_alignment)
 
 If the alternate sequence of a haplotype is no longer available (as is often the
 case when calling variants from alignment files), then the sequence can be
-retrieved using the [`reconstruct!`](@ref) function.
+retrieved using the [`reconstruct`](@ref) function.
 
 ```@repl call_variants
 human2 = copy(bovine);
-reconstruct!(human2, bos_human_haplotype)
+reconstruct(human2, bos_human_haplotype)
 human2 == bovine
 human2 == human
 ```

--- a/src/Haplotype.jl
+++ b/src/Haplotype.jl
@@ -162,11 +162,11 @@ reference(h::Haplotype) = h.ref
 Base.:(==)(x::Haplotype, y::Haplotype) = x.ref == y.ref && x.edits == y.edits
 
 """
-    reconstruct!(h::Haplotype)
+    reconstruct(h::Haplotype)
 
 Apply the edits in `h` to the reference sequence of `h` and return the mutated sequence
 """
-function reconstruct!(h::Haplotype)
+function reconstruct(h::Haplotype)
     len = length(reference(h)) + sum(edit -> _lendiff(edit), _edits(h))
     seq = copy(reference(h))
     resize!(seq, len % UInt)

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -32,7 +32,7 @@ export Substitution
 export Variation
 export altbases
 export mutation
-export reconstruct!
+export reconstruct
 export refbases
 export reference
 export translate

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,10 @@ var = Haplotype(align(seq1, seq2))
     end
 end
 
+@testset "HaplotypeReconstruction" begin
+    @test reconstruct(var) == seq1
+end
+
 @testset "VariationPosition" begin
     refseq = dna"ACAACTTTATCT"
     mutseq = dna"ACATCTTTATCT"


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [x] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

### Previous behavior

`reconstruct!` required a reference sequence, even though the `Haplotype` type contains the proper reference sequence. It was also a mutating function, which led to a few cases of unexpected behavior and/or lots of cluttered `copy` statements for me.

```julia
# setup
using SequenceVariation, BioAlignments, BioSequences
bovine = dna"GACCGGCTGCATTCGAGGCTGCCAGCAAGCAG"
human  = dna"GACAGGCTGCATCAGAAGAGGCCATCAAGCAG"
bos_human_alignment =
    PairwiseAlignment(AlignedSequence(human, Alignment("32M", 1, 1)), bovine)
bos_human_haplotype = Haplotype(bos_human_alignment)

# behavior
human2 = copy(bovine)
reconstruct!(human2, bos_human_haplotype)
```

### New behavior

`reconstruct` is now a single-argument function, accesses the reference sequence within the `Haplotype` argument, and returns a new sequence.

```julia
# setup
using SequenceVariation, BioAlignments, BioSequences
bovine = dna"GACCGGCTGCATTCGAGGCTGCCAGCAAGCAG"
human  = dna"GACAGGCTGCATCAGAAGAGGCCATCAAGCAG"
bos_human_alignment =
    PairwiseAlignment(AlignedSequence(human, Alignment("32M", 1, 1)), bovine)
bos_human_haplotype = Haplotype(bos_human_alignment)

# behavior
human2 = reconstruct(bos_human_haplotype)
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
