### PR TITLE
Add `translate` functionality for haplotypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `translate` functionality for `Haplotype`s ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
+
 ## [0.2.0] - 2023-01-10
 
 ### Added
 
 - Tutorial-type documentation ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
-- `Base.isless` implementation for `Edit` and `Variation` ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
+- `Base.isless` implementation for `Edit` and `Variation` ([#32](https://github.com/BioJulia/SequenceVariation.jl/pull/32))
 
 ### Changed
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -22,6 +22,7 @@ Haplotype
 reference(::Haplotype)
 variations
 reconstruct
+translate(::Haplotype{S,T}, ::PairwiseAlignment{S,S}) where {S,T}
 ```
 
 ## Variations
@@ -30,7 +31,7 @@ reconstruct
 Variation
 reference(::Variation)
 mutation
-translate
+translate(::Variation{S,T}, ::PairwiseAlignment{S,S}) where {S,T}
 refbases
 altbases
 ```

--- a/docs/src/haplotypes.md
+++ b/docs/src/haplotypes.md
@@ -38,3 +38,18 @@ human2 = reconstruct(bos_human_haplotype)
 human2 == bovine
 human2 == human
 ```
+
+## Reference switching
+
+All variations within a haplotype can be mapped to a new reference sequence
+given an alignment between the new and old references using the
+[`translate`](@ref translate(::Haplotype{S,T}, ::PairwiseAlignment{S,S}) where {S,T})
+function. This could be useful if variants were called against a reference
+sequence for the entire species, but need to be analyzed as variants of a
+subtype later.
+
+```@repl call_variants
+ovis_human_alignment =
+    PairwiseAlignment(AlignedSequence(human, Alignment("32M", 1, 1)), ovine)
+SequenceVariation.translate(bos_ovis_haplotype, ovis_human_alignment)
+```

--- a/docs/src/variations.md
+++ b/docs/src/variations.md
@@ -54,13 +54,15 @@ variations(bos_human_haplotype)
 ## Reference switching
 
 An individual variation can be mapped to a new reference sequence given an
-alignment between the new and old references using the [`translate`](@ref).
+alignment between the new and old references using the
+[`translate`](@ref translate(::Variation{S,T}, ::PairwiseAlignment{S,S}) where {S,T})
+function.
 
 ```@repl call_variants
 ovis_human_alignment =
     PairwiseAlignment(AlignedSequence(human, Alignment("32M", 1, 1)), ovine)
 human_variation = first(variations(bos_ovis_haplotype))
 reference(ans) == bovine
-SequenceVariation.translate(human_variation, ovis_human_haplotype)
+SequenceVariation.translate(human_variation, ovis_human_alignment)
 reference(ans) == bovine
 ```

--- a/src/Haplotype.jl
+++ b/src/Haplotype.jl
@@ -198,3 +198,23 @@ function reconstruct(h::Haplotype)
     end
     return seq
 end
+
+"""
+    translate(hap::Haplotype{S,T}, aln::PairwiseAlignment{S,S}) where {S,T}
+
+Convert the variations in `hap` to a new reference sequence based upon `aln`. The alignment
+rules follow the conventions of
+[`translate(::Variation, PairwiseAlignment)`](@ref translate(::Variation{S,T}, ::PairwiseAlignment{S,S}) where {S,T}).
+Indels at the beginning or end may not be preserved. Returns a new
+[`Haplotype`](@ref)
+"""
+function translate(hap::Haplotype{S,T}, aln::PairwiseAlignment{S,S}) where {S,T}
+    vars = variations(hap)
+    new_ref = BA.sequence(aln)
+    translated_vars = Variation{S,T}[]
+    for v in vars
+        new_v = translate(v, aln)
+        isnothing(new_v) || push!(translated_vars, new_v)
+    end
+    return Haplotype(new_ref, translated_vars)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,16 @@ end
     @test Variation(seq2, "A3T") < Variation(seq2, "T4A")
 end
 
+@testset "HaplotypeTranslation" begin
+    ref1 = seq2
+    ref2 = seq3
+    alt = seq1
+
+    @test all(
+        v -> v in Haplotype(align(alt, ref2)), variations(translate(var, align(ref2, ref1)))
+    )
+end
+
 @testset "VariationPosition" begin
     refseq = dna"ACAACTTTATCT"
     mutseq = dna"ACATCTTTATCT"


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Adds a `translate` function for haplotypes. This, in my mind, is far more useful as it would allow me to recycle my work calling variants on, e.g. the reference genome of JEV, by re-calling the same variants on a known subtype, e.g. JEV-SA14.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
