### PR TITLE
Add `isless` for `Edit` and `Variation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Tutorial-type documentation ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
+- `Base.isless` implementation for `Edit` and `Variation` ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
 
 ### Changed
 

--- a/src/Edit.jl
+++ b/src/Edit.jl
@@ -17,6 +17,13 @@ end
 Base.length(e::Edit) = length(_mutation(e))
 Base.:(==)(e1::Edit, e2::Edit) = e1.pos == e2.pos && e1.x == e2.x
 Base.hash(x::Edit, h::UInt) = hash(Edit, hash((x.x, x.pos), h))
+function Base.isless(x::Edit, y::Edit)
+    if leftposition(x) == leftposition(y)
+        return length(x) < length(y)
+    end
+
+    return leftposition(x) < leftposition(y)
+end
 
 function Base.parse(::Type{T}, s::AbstractString) where {T<:Edit{Se,Sy}} where {Se,Sy}
     return parse(T, String(s))

--- a/src/Variation.jl
+++ b/src/Variation.jl
@@ -75,6 +75,11 @@ BioGenerics.leftposition(v::Variation) = leftposition(_edit(v))
 BioGenerics.rightposition(v::Variation) = rightposition(_edit(v))
 Base.:(==)(x::Variation, y::Variation) = x.ref == y.ref && x.edit == y.edit
 Base.hash(x::Variation, h::UInt) = hash(Variation, hash((x.ref, x.edit), h))
+function Base.isless(x::Variation, y::Variation)
+    reference(x) == reference(y) ||
+        error("Variations cannot be compared if their reference sequences aren't equal")
+    return leftposition(x) < leftposition(y)
+end
 
 """
     _is_valid(v::Variation)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,10 @@ end
     @test reconstruct(var) == seq1
 end
 
+@testset "VariationSorting" begin
+    @test Variation(seq2, "A3T") < Variation(seq2, "T4A")
+end
+
 @testset "VariationPosition" begin
     refseq = dna"ACAACTTTATCT"
     mutseq = dna"ACATCTTTATCT"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,15 @@ seq1 = ungap!(dna"--ATGCGTGTTAGCAAC--TTATCGCG")
 seq2 = ungap!(dna"TGATGCGTGT-AGCAACACTTATAGCG")
 var = Haplotype(align(seq1, seq2))
 
+@testset "EditSorting" begin
+    S = typeof(seq1)
+    T = eltype(seq1)
+    @test SequenceVariation.Edit{S,T}(Deletion(1), 1) <
+        SequenceVariation.Edit{S,T}(Deletion(1), 2)
+    @test SequenceVariation.Edit{S,T}(Deletion(1), 1) <
+        SequenceVariation.Edit{S,T}(Deletion(2), 1)
+end
+
 @testset "HaplotypeRoundtrip" begin
     for v in variations(var)
         @test v in var


### PR DESCRIPTION
This PR implements the following changes:

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

### Description

`Edit`s and `Variation`s need to be sorted to add them to a `Haplotype`, but didn't provide a method to do so. This patch fixes that.

#### Before

```julia
using BioSequences, BioSymbols, SequenceVariation

SequenceVariation.Edit{LongDNA{2},DNA}(Deletion(1), 1) < SequenceVariation.Edit{LongDNA{2},DNA}(Deletion(1), 2)

# output
ERROR: MethodError: no method matching isless(::SequenceVariation.Edit{LongSequence{DNAAlphabet{2}}, DNA}, ::SequenceVariation.Edit{LongSequence{DNAAlphabet{2}}, DNA})
Closest candidates are:
  isless(::Any, ::Missing) at missing.jl:88
  isless(::Missing, ::Any) at missing.jl:87
Stacktrace:
 [1] <(x::SequenceVariation.Edit{LongSequence{DNAAlphabet{2}}, DNA}, y::SequenceVariation.Edit{LongSequence{DNAAlphabet{2}}, DNA})
   @ Base ./operators.jl:279
 [2] top-level scope
   @ REPL[5]:1
```

```julia
using BioSequences, SequenceVariation

Variation(dna"AAA", "A1C") < Variation(dna"AAA", "A3C")

# output
ERROR: MethodError: no method matching isless(::Variation{LongSequence{DNAAlphabet{4}}, DNA}, ::Variation{LongSequence{DNAAlphabet{4}}, DNA})
Closest candidates are:
  isless(::Any, ::Missing) at missing.jl:88
  isless(::Missing, ::Any) at missing.jl:87
Stacktrace:
 [1] <(x::Variation{LongSequence{DNAAlphabet{4}}, DNA}, y::Variation{LongSequence{DNAAlphabet{4}}, DNA})
   @ Base ./operators.jl:279
 [2] top-level scope
   @ REPL[6]:1
```

#### This patch

```julia
using BioSequences, BioSymbols, SequenceVariation

SequenceVariation.Edit{LongDNA{2},DNA}(Deletion(1), 1) < SequenceVariation.Edit{LongDNA{2},DNA}(Deletion(1), 2)

# output
true
```

```julia
using BioSequences, SequenceVariation

Variation(dna"AAA", "A1C") < Variation(dna"AAA", "A3C")

# output
true
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
