### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-01-10
+
 ### Added
 
 - Tutorial-type documentation ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
@@ -61,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Variant` constructor to automatically detect mutations from a `BioAlignments.PairwiseAlignment`
 - Methods to get reference and alternate bases from a `Variation`
 
-[unreleased]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.4...HEAD
+[unreleased]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.1...v0.1.2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SequenceVariation"
 uuid = "eef6e190-9969-4f06-a38f-35a110a8fdc8"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>", "Thomas A. Christensen II <25492070+MillironX@users.noreply.github.com>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ add SequenceVariation
 
 ## Testing
 
-SequenceVariation is tested against Julia `1.X` on Linux, OS X, and Windows.
+SequenceVariation is tested against Julia `1.6` (LTS), `1.X` (release) and nightly on Linux.
 
 **Latest build status:**
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ add SequenceVariation
 
 ## Testing
 
-SequenceVariation is tested against Julia `1.X` on Linux, OS X, and Windows.
+SequenceVariation is tested against Julia `1.6` (LTS), `1.X` (release) and nightly on Linux.
 
 **Latest build status:**
 


### PR DESCRIPTION
It's time for a new release. This release contains:

> ## [0.2.0] - 2023-01-10
> 
> ### Added
>
> - Tutorial-type documentation ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
> - `Base.isless` implementation for `Edit` and `Variation` ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
>
> ### Changed
>
> - Code now follows [Blue style](https://github.com/invenia/BlueStyle) ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
> - :bomb: [BREAKING] Public and private API defined based on Blue style guidelines ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))
> - :bomb: [BREAKING] Renamed type `Variant` to `Haplotype` ([#20](https://github.com/BioJulia/SequenceVariation.jl/issues/20)/[#29](https://github.com/BioJulia/SequenceVariation.jl/pull/29))
> - :bomb: [BREAKING] Refactored `reconstruct` function to use `Haplotype`'s reference sequence ([#30](https://github.com/BioJulia/SequenceVariation.jl/pull/30))
> 
> ### Removed
>
> - Windows and MacOS CI tests ([#28](https://github.com/BioJulia/SequenceVariation.jl/pull/28))