### PR TITLE
Better error descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `translate` functionality for `Haplotype`s ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
+- More informative errors when constructing invalid `Haplotype`s ([#34](https://github.com/BioJulia/SequenceVariation.jl/pull/34))
 
 ## [0.2.0] - 2023-01-10
 


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Invalid `Haplotypes` now return useful error messages.

### Before

```julia
ref = dna"GATTACA"
hap = Haplotype(
    ref,
    [
        Variation(ref, "Δ2-4"),
        Variation(ref, "A2G"),
    ],
)

#output
ERROR: TODO
[...]
```

### This patch

```julia
ref = dna"GATTACA"
hap = Haplotype(
    ref,
    [
        Variation(ref, "Δ2-4"),
        Variation(ref, "A2G"),
    ],
)

#output
ERROR: Multiple modifications at same position
[...]
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
