### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-01-11
+
 ### Added
 
 - `translate` functionality for `Haplotype`s ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
@@ -68,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Variant` constructor to automatically detect mutations from a `BioAlignments.PairwiseAlignment`
 - Methods to get reference and alternate bases from a `Variation`
 
-[unreleased]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/BioJulia/SequenceVariation.jl/compare/v0.1.2...v0.1.3

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SequenceVariation"
 uuid = "eef6e190-9969-4f06-a38f-35a110a8fdc8"
 authors = ["Jakob Nybo Nissen <jakobnybonissen@gmail.com>", "Thomas A. Christensen II <25492070+MillironX@users.noreply.github.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 BioAlignments = "00701ae9-d1dc-5365-b64a-a3a3ebf5695e"


### PR DESCRIPTION
PR for CI testing and documentation build for v0.2.1. This update includes:

> ### Added
> 
> - `translate` functionality for `Haplotype`s ([#31](https://github.com/BioJulia/SequenceVariation.jl/pull/31))
> - More informative errors when constructing invalid `Haplotype`s ([#34](https://github.com/BioJulia/SequenceVariation.jl/pull/34))