### PR TITLE
Fix validation for Haplotypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Haplotype` validation ([#36](https://github.com/BioJulia/SequenceVariation.jl/issues/36)/[#37](https://github.com/BioJulia/SequenceVariation.jl/pull/37))
+
 ## [0.2.1] - 2023-01-11
 
 ### Added

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,41 @@ var = Haplotype(align(seq1, seq2))
         SequenceVariation.Edit{S,T}(Deletion(2), 1)
 end
 
+@testset "HaplotypeValidation" begin
+    # Test that substitutions cannot share the same position
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "T2A"), Variation(seq2, "T2C")]
+    )
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "G2A"), Variation(seq2, "G2T")]
+    )
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "G26A"), Variation(seq2, "G26T")]
+    )
+
+    # Test that insertions cannot share the same position
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "0AAA"), Variation(seq2, "0TTT")]
+    )
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "2AAA"), Variation(seq2, "2TTT")]
+    )
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "26AAA"), Variation(seq2, "26TTT")]
+    )
+
+    # Test that deletions invalidate further operations within the deleted positions
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "Δ2-2"), Variation(seq2, "G2A")]
+    )
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "G2A"), Variation(seq2, "Δ2-2")]
+    )
+    @test_throws ErrorException Haplotype(
+        seq2, [Variation(seq2, "Δ2-6"), Variation(seq2, "Δ3-5")]
+    )
+end
+
 @testset "HaplotypeRoundtrip" begin
     for v in variations(var)
         @test v in var

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,9 @@ seq2 = ungap!(dna"TGATGCGTGT-AGCAACACTTATAGCG")
 seq3 = ungap!(dna"-GATGCGTGT-AGCAACACTTATCGC-")
 var = Haplotype(align(seq1, seq2))
 
+const SEQ = typeof(seq1)
+const BSE = eltype(seq1)
+
 @testset "EditSorting" begin
     S = typeof(seq1)
     T = eltype(seq1)
@@ -55,6 +58,11 @@ var = Haplotype(align(seq1, seq2))
 end
 
 @testset "HaplotypeValidation" begin
+    # Test that we can't use an empty reference
+    @test_throws ErrorException Haplotype(
+        dna"", [SequenceVariation.Edit{SEQ,BSE}(Insertion{SEQ}(dna"A"), 0)]
+    )
+
     # Test that substitutions cannot share the same position
     @test_throws ErrorException Haplotype(
         seq2, [Variation(seq2, "T2A"), Variation(seq2, "T2C")]
@@ -86,6 +94,21 @@ end
     )
     @test_throws ErrorException Haplotype(
         seq2, [Variation(seq2, "Δ2-6"), Variation(seq2, "Δ3-5")]
+    )
+
+    # Test that a complicated (but valid) Haplotype still checks out
+    @test first(
+        SequenceVariation._is_valid(
+            Haplotype(
+                seq2,
+                [
+                    Variation(seq2, "0AAA"),
+                    Variation(seq2, "T2A"),
+                    Variation(seq2, "Δ5-8"),
+                    Variation(seq2, "G26A"),
+                ],
+            ),
+        ),
     )
 end
 


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

- [ ] :sparkles: New feature (A non-breaking change which adds functionality).
- [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Fixes #36 

I've added a ton of validation tests and refactored the `_is_valid(::Haplotype)` function to provide correctness.

### Runnable example

```julia
using BioSequences, SequenceVariation, BenchmarkTools
seq2 = dna"TGATGCGTGTAGCAACACTTATAGCG"

invalid_haplotype = Haplotype(
    seq2, [Variation(seq2, "T2A"), Variation(seq2, "T2C")]
)

@show invalid_haplotype

valid_haplotype = Haplotype(
    seq2,
    [
        Variation(seq2, "0AAA"),
        Variation(seq2, "T2A"),
        Variation(seq2, "Δ5-8"),
        Variation(seq2, "G26A"),
    ],
)

@benchmark SequenceVariation._is_valid(valid_haplotype)
```

#### Previous Results

```plaintext
invalid_haplotype = Haplotype{LongSequence{DNAAlphabet{4}}, DNA} with 2 edits:
  G2A
  G2C
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  22.028 ns …  2.094 μs  ┊ GC (min … max): 0.00% … 94.65%
 Time  (median):     23.143 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   25.932 ns ± 51.773 ns  ┊ GC (mean ± σ):  5.14% ±  2.55%

  ▄█▆▆▆▅▅▄▄▄▄▃▂            ▁ ▁▂▂▂▂▂▂▁                         ▂
  ██████████████▇▇▇▇▇▅▆▇▇▇▇█████████████▇█▇███▇▆▆▆▆▆▆▆▆▆▆▆▆▅▅ █
  22 ns        Histogram: log(frequency) by time      37.4 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.
```

#### This PR Results

```plaintext
ERROR: LoadError: Multiple modifications at same position
[...]
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  28.305 ns …  2.353 μs  ┊ GC (min … max): 0.00% … 97.24%
 Time  (median):     29.393 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   32.322 ns ± 59.284 ns  ┊ GC (mean ± σ):  4.75% ±  2.56%

   ▃▆█▇▆▄▃▁▁                    ▁▁▂▁▂▂▁▁                      ▂
  ▅███████████▇▇▇▇█▆▅▅▆▆▇▇▇█████████████████▆█▆▆▆▆▅▅▅▅▆▆▇▆▆▅▆ █
  28.3 ns      Histogram: log(frequency) by time      43.7 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.
```

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
