### PR TITLE
[Feature]: Add `alignment` and `cigar` getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `alignment` and `cigar` getters for `Haplotype`s ([#39](https://github.com/BioJulia/SequenceVariation.jl/issues/39)/[#42](https://github.com/BioJulia/SequenceVariation.jl/pull/42))
+
 ## [0.2.2] - 2023-01-28
 
 ### Fixed

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -22,6 +22,7 @@ Haplotype
 reference(::Haplotype)
 variations
 reconstruct
+BioAlignments.alignment
 translate(::Haplotype{S,T}, ::PairwiseAlignment{S,S}) where {S,T}
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,6 +23,7 @@ reference(::Haplotype)
 variations
 reconstruct
 BioAlignments.alignment
+BioAlignment.cigar
 translate(::Haplotype{S,T}, ::PairwiseAlignment{S,S}) where {S,T}
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,7 +15,7 @@ Deletion
 Insertion
 ```
 
-## Variants
+## Haplotypes
 
 ```@docs
 Haplotype

--- a/docs/src/haplotypes.md
+++ b/docs/src/haplotypes.md
@@ -39,6 +39,24 @@ human2 == bovine
 human2 == human
 ```
 
+## Alignment reconstruction
+
+Just like [Sequence reconstruction](@ref), alignments can also be reconstructed
+from `Haplotype`s using the extension of the [`BioAlignments.alignment`](@ref)
+function.
+
+```@repl call_variants
+human_alignment = alignment(bos_human_haplotype)
+human_alignment == bos_human_alignment
+```
+
+Alternatively, you can get the information in CIGAR format using the
+extension of the [`BioAlignments.cigar`](@ref) function.
+
+```@repl call_variants
+cigar(bos_human_haplotype)
+```
+
 ## Reference switching
 
 All variations within a haplotype can be mapped to a new reference sequence

--- a/src/Haplotype.jl
+++ b/src/Haplotype.jl
@@ -251,6 +251,17 @@ function BioAlignments.cigar(hap::Haplotype{S,T}) where {S,T}
 end
 
 """
+    alignment(hap::Haplotype)
+
+Gets a `PairwiseAlignment` of the mutated sequence of `hap` mapped to its refernce sequence
+"""
+function BioAlignments.alignment(hap::Haplotype)
+    return PairwiseAlignment(
+        AlignedSequence(reconstruct(hap), Alignment(cigar(hap))), reference(hap)
+    )
+end
+
+"""
     translate(hap::Haplotype{S,T}, aln::PairwiseAlignment{S,S}) where {S,T}
 
 Convert the variations in `hap` to a new reference sequence based upon `aln`. The alignment

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -20,7 +20,7 @@ TODO now:
 * Add tests
 """
 
-using BioAlignments: BioAlignments, PairwiseAlignment, OP_SOFT_CLIP, sequence
+using BioAlignments: BioAlignments, PairwiseAlignment, OP_SOFT_CLIP, cigar, sequence
 using BioGenerics: BioGenerics, leftposition, rightposition
 using BioSequences: BioSequences, BioSequence, NucleotideSeq, LongSequence, isgap
 using BioSymbols: BioSymbol

--- a/src/SequenceVariation.jl
+++ b/src/SequenceVariation.jl
@@ -20,7 +20,15 @@ TODO now:
 * Add tests
 """
 
-using BioAlignments: BioAlignments, PairwiseAlignment, OP_SOFT_CLIP, cigar, sequence
+using BioAlignments:
+    BioAlignments,
+    Alignment,
+    AlignedSequence,
+    PairwiseAlignment,
+    OP_SOFT_CLIP,
+    alignment,
+    cigar,
+    sequence
 using BioGenerics: BioGenerics, leftposition, rightposition
 using BioSequences: BioSequences, BioSequence, NucleotideSeq, LongSequence, isgap
 using BioSymbols: BioSymbol

--- a/src/Variation.jl
+++ b/src/Variation.jl
@@ -121,6 +121,21 @@ function Base.in(v::Variation, var::Haplotype)
 end
 
 """
+    _cigar(var::Variation{S,T}) where {S,T}
+
+Returns a CIGAR operation for `var`. Only supports insertions and deletions.
+
+See also [`_cigar_between`](@ref)
+"""
+function _cigar(var::Variation{S,T}) where {S,T}
+    mut = mutation(var)
+    mut isa Union{Deletion,Insertion} ||
+        throw(ArgumentError("var must be an Insertion or Deletion"))
+    cigar_letter = mut isa Deletion ? 'D' : 'I'
+    return string(length(mut), cigar_letter)
+end
+
+"""
     translate(var::Variation{S,T}, aln::PairwiseAlignment{S,S}) where {S,T}
 
 Convert the difference in `var` to a new reference sequence based upon `aln`. `aln` is the

--- a/src/Variation.jl
+++ b/src/Variation.jl
@@ -136,6 +136,26 @@ function _cigar(var::Variation{S,T}) where {S,T}
 end
 
 """
+    _cigar_between(x::Variation{S,T}, y::Variation{S,T}) where {S,T}
+
+Returns a CIGAR operation for the (assumed) matching bases between `x` and `y`.
+
+See also [`_cigar`](@ref)
+"""
+function _cigar_between(x::Variation{S,T}, y::Variation{S,T}) where {S,T}
+    x == y && return ""
+    match_length = leftposition(y) - rightposition(x)
+    if mutation(y) isa Insertion
+        match_length -= 1
+    end
+    if mutation(y) isa Deletion
+        match_length += 1
+    end
+    match_length > 0 || return ""
+    return "$(match_length)M"
+end
+
+"""
     translate(var::Variation{S,T}, aln::PairwiseAlignment{S,S}) where {S,T}
 
 Convert the difference in `var` to a new reference sequence based upon `aln`. `aln` is the

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ using BioAlignments:
     Alignment,
     AlignedSequence,
     PairwiseAlignment,
+    alignment,
     cigar
 using BioSequences: BioSequence, @dna_str, ungap!
 using BioSymbols: DNA_A
@@ -145,6 +146,12 @@ end
 
     @test cigar(reference_genotype) == "26M"
     @test cigar(genotype) == "2D7M1I7M2D8M"
+end
+
+@testset "HaplotypeAlignment" begin
+    # This test is broken until we get a way to remove sequence info from alignments
+    # See: https://github.com/BioJulia/BioAlignments.jl/issues/90
+    @test_broken alignment(var) == align(seq1, seq2)
 end
 
 @testset "HaplotypeTranslation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,8 @@ using BioAlignments:
     pairalign,
     Alignment,
     AlignedSequence,
-    PairwiseAlignment
+    PairwiseAlignment,
+    cigar
 using BioSequences: BioSequence, @dna_str, ungap!
 using BioSymbols: DNA_A
 using SequenceVariation
@@ -125,6 +126,25 @@ end
 
 @testset "VariationSorting" begin
     @test Variation(seq2, "A3T") < Variation(seq2, "T4A")
+end
+
+@testset "CIGAR" begin
+    reference = dna"TGATGCGTGTAGCAACACTTATAGCG"
+    reference_genotype = Haplotype(
+        reference, Variation{typeof(reference),eltype(reference)}[]
+    )
+    genotype = Haplotype(
+        reference,
+        [
+            Variation(reference, "Δ1-2"),
+            Variation(reference, "10T"),
+            Variation(reference, "Δ17-18"),
+            Variation(reference, "A23C"),
+        ],
+    )
+
+    @test cigar(reference_genotype) == "26M"
+    @test cigar(genotype) == "2D7M1I7M2D8M"
 end
 
 @testset "HaplotypeTranslation" begin


### PR DESCRIPTION
Closes #39 

## Types of changes

This PR implements the following changes:

- [x] :sparkles: New feature (A non-breaking change which adds functionality).
- [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Add methods to `BioAlignments.alignment` and `BioAlignments.cigar` to pull a `PairwiseAlignment` and CIGAR string from a `Haplotype`, respectively.

See [the updated docs](https://github.com/BioJulia/SequenceVariation.jl/tree/6b2bd018e2e6b5cdd1817b886d0fbe868305d1f7) for runnable examples.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/v1/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
